### PR TITLE
feat(sidebar): made sidebar resizable and no overflow layout 

### DIFF
--- a/app/(main)/editor/page.tsx
+++ b/app/(main)/editor/page.tsx
@@ -1,33 +1,64 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useRef } from "react";
 
 import ClientOnly from "@/components/ClientOnly";
 import { Editor } from "@/components/core/Editor";
 
 export default function DashboardPage() {
-  const [initialContent, setInitialContent] = useState<string>("");
+  const isResizing = useRef<boolean>(false);
 
-  useEffect(() => {
-    const inknote_ctx = localStorage.getItem("inknote");
-    if (inknote_ctx) setInitialContent(inknote_ctx);
-  }, []);
+  const editorRef = useRef<HTMLDivElement | null>(null);
+  const sidebarRef = useRef<HTMLDivElement | null>(null);
 
-  function onChangeAction(ctx: string) {
-    localStorage.setItem("inknote", ctx);
-  }
+  const onMouseUp = () => {
+    isResizing.current = false;
+
+    editorRef.current!.style.cursor = "default";
+    editorRef.current!.style.userSelect = "auto";
+
+    document.removeEventListener("mouseup", onMouseUp);
+    document.removeEventListener("mousemove", onMouseMove);
+  };
+
+  const onMouseDown = () => {
+    isResizing.current = true;
+
+    editorRef.current!.style.userSelect = "none";
+    editorRef.current!.style.cursor = "ew-resize";
+
+    document.addEventListener("mouseup", onMouseUp);
+    document.addEventListener("mousemove", onMouseMove);
+  };
+
+  const onMouseMove = (e: any) => {
+    if (!isResizing.current && !sidebarRef.current) return;
+
+    let width = e.clientX;
+
+    if (width < 200) width = 200;
+    if (width > 500) width = 500;
+
+    sidebarRef.current!.style.width = `${width}px`;
+  };
 
   return (
     <>
-      <div className="w-full">
+      <aside
+        ref={sidebarRef}
+        className="w-64 flex justify-between group/sidebar"
+      >
+        Another div
+        <div
+          className="h-full w-1 cursor-ew-resize group-hover/sidebar:bg-gray-300"
+          onMouseDown={onMouseDown}
+        ></div>
+      </aside>
+      <section ref={editorRef} className="flex-1 overflow-y-auto">
         <ClientOnly>
-          <Editor
-            editable={true}
-            initialContent={initialContent}
-            onChangeAction={onChangeAction}
-          />
+          <Editor />
         </ClientOnly>
-      </div>
+      </section>
     </>
   );
 }

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,5 +1,7 @@
 export default function MainLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
-  return <div className="h-screen w-full flex">{children}</div>;
+  return (
+    <main className="h-screen w-full flex overflow-hidden">{children}</main>
+  );
 }


### PR DESCRIPTION
Made sidebar resizable and the cursor to resizing cursor while resizing over the main section and made the entire editor layout to `overflow: none` and the editor layout overflow-y to auto. This will prevent the overflows made by body.